### PR TITLE
Update conda

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -37,6 +37,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
+conda update --yes --all
+
 conda info
 
 


### PR DESCRIPTION
`hdfeos2` and `hdfeos5` need latest conda to work around

`uncompress is required to unarchive .z source files. ./ci_support/run_docker_build.sh returned exit code 1`

@pelson I guess I should do this in `conda-smithy`.
