### PR TITLE
No libgcc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: b8648484fc78a2db7073dd603f3fb251
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
 
 requirements:
@@ -20,7 +20,6 @@ requirements:
         - hdf4
         - zlib
         - jpeg
-        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
This package does not link to `libgomp` so we don't need `libgcc` as a `run` requirement.
