### PR TITLE
Install header files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,8 @@ export CFLAGS="-fPIC"
 ./configure --prefix=${PREFIX} \
             --with-hdf4=${PREFIX} \
             --with-zlib=${PREFIX} \
-            --with-jpeg=${PREFIX}
+            --with-jpeg=${PREFIX} \
+            --enable-install-include
 
 make
 make check


### PR DESCRIPTION
With the actual build, some header files are not installed (`gctp_prototypes.h`, `cproj_prototypes.h`, etc.). These files are needed to build other scientific softwares. The `--enable-install-include` switch solves the issue.
